### PR TITLE
feat: add support for system theme preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,36 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MD Reader</title>
+    <script>
+      (function () {
+        const THEME_STORAGE_KEY = "md-reader-theme";
+        try {
+          const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+          const prefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)"
+          ).matches;
+
+          let theme = "light";
+          if (stored === "dark" || stored === "light") {
+            theme = stored;
+          } else {
+            theme = prefersDark ? "dark" : "light";
+          }
+
+          const root = document.documentElement;
+          root.setAttribute("data-theme", theme);
+          root.style.colorScheme = theme;
+        } catch (e) {}
+      })();
+    </script>
+    <style>
+      html[data-theme="dark"] {
+        background-color: #0d1117;
+      }
+      html[data-theme="light"] {
+        background-color: #ffffff;
+      }
+    </style>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tauri-apps/plugin-dialog": "^2.0.1",
     "@tauri-apps/plugin-fs": "^2.0.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
+    "@tauri-apps/plugin-store": "^2.4.4",
     "codemirror": "^6.0.2",
     "dompurify": "^3.2.3",
     "highlight.js": "^11.10.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
+tauri-plugin-store = "2"
 window-vibrancy = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "fs:default",
     "opener:default",
     "window-state:default",
+    "store:default",
     "fs:allow-read-text-file",
     "fs:allow-read-file",
     "fs:allow-write-text-file",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,11 +6,16 @@ use std::time::Duration;
 use notify_debouncer_mini::notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 use serde::Serialize;
+use tauri::Manager;
+use tauri_plugin_store::StoreExt;
 
 mod pdf_export;
 mod pdf_utils;
 
 use pdf_utils::{current_millis, strip_windows_extended_prefix};
+
+const STORAGE_FILE: &str = "settings.json";
+const THEME_STORAGE_KEY: &str = "md-reader-theme";
 
 #[cfg(target_os = "windows")]
 fn apply_windows_frame_theme(window: &tauri::WebviewWindow, is_dark: bool) {
@@ -46,6 +51,7 @@ fn extract_md_path_from_args(argv: &[String]) -> Option<String> {
     }
     None
 }
+
 use tauri::{Emitter, State};
 use walkdir::WalkDir;
 
@@ -428,18 +434,26 @@ fn register_file_associations() -> Result<(), String> {
 }
 
 #[tauri::command]
-fn set_app_theme(window: tauri::WebviewWindow, theme: String) -> Result<(), String> {
-    let is_dark = theme == "dark";
+fn set_theme_mode(window: tauri::WebviewWindow, theme_mode: String) -> Result<(), String> {
+    let theme_option = match theme_mode.as_str() {
+        "dark" => Some(tauri::Theme::Dark),
+        "light" => Some(tauri::Theme::Light),
+        "system" | _ => None, // 传入 None 可恢复对操作系统的监听
+    };
+
     window
-        .set_theme(Some(if is_dark {
-            tauri::Theme::Dark
-        } else {
-            tauri::Theme::Light
-        }))
+        .set_theme(theme_option)
         .map_err(|e| e.to_string())?;
-    apply_windows_frame_theme(&window, is_dark);
+
     Ok(())
 }
+
+#[tauri::command]
+fn set_effective_theme(window: tauri::WebviewWindow, theme: String) -> Result<(), String> {
+    apply_windows_frame_theme(&window, theme == "dark");
+    Ok(())
+}
+
 #[tauri::command]
 fn initial_open_file() -> Option<String> {
     let argv: Vec<String> = std::env::args().collect();
@@ -451,7 +465,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             // Already-running instance: focus window and emit the new file path.
-            use tauri::{Emitter, Manager};
+            use tauri::Emitter;
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -464,14 +478,22 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(tauri_plugin_store::Builder::new().build())
         .setup(|app| {
-            use tauri::Manager;
             app.manage(WatcherState::default());
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_theme(None);
-                apply_windows_frame_theme(&window, false);
+
+            let window = app.get_webview_window("main").unwrap();
+            let store = app.store(STORAGE_FILE)?;
+            if let Some(theme) = store.get(THEME_STORAGE_KEY) {
+                if theme.eq("light") {
+                    window.set_theme(Some(tauri::Theme::Light))?;
+                    apply_windows_frame_theme(&window, false);
+                } else if theme.eq("dark") {
+                    window.set_theme(Some(tauri::Theme::Dark))?;
+                    apply_windows_frame_theme(&window, true);
+                }
             }
-            let _ = app;
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -481,7 +503,8 @@ pub fn run() {
             search_in_files,
             initial_open_file,
             register_file_associations,
-            set_app_theme,
+            set_theme_mode,
+            set_effective_theme,
             check_pandoc,
             export_with_pandoc,
             pdf_utils::check_pdf_engine,

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,7 @@ import {
   printDocument,
   type PandocInfo,
 } from "./composables/useExport";
+import { useTheme } from "./composables/useTheme.ts";
 
 const { t, locale } = useI18n();
 
@@ -110,9 +111,6 @@ function scheduleSuppressClear(p: string) {
   window.setTimeout(() => clearSuppress(p), 1000);
 }
 
-const theme = ref<"light" | "dark">(
-  (localStorage.getItem("md-reader-theme") as "light" | "dark") || "light"
-);
 const showFileTree = ref<boolean>(
   localStorage.getItem("md-reader-show-tree") !== "0"
 );
@@ -620,19 +618,21 @@ async function restoreTabs(initialPath = "") {
   if (initialPath) await loadFile(initialPath);
 }
 
+const { themeMode, effectiveTheme } = useTheme();
+
+const themeIcon = computed(() => {
+  if (themeMode.value === "light") return "☀️";
+  if (themeMode.value === "dark") return "🌙";
+  return "🌗";
+});
+
 function toggleTheme() {
-  theme.value = theme.value === "light" ? "dark" : "light";
-  localStorage.setItem("md-reader-theme", theme.value);
-  applyTheme();
+  if (themeMode.value === "system") themeMode.value = "light";
+  else if (themeMode.value === "light") themeMode.value = "dark";
+  else themeMode.value = "system";
+
   // Force Mermaid/KaTeX re-render so charts follow the new theme.
   renderTick.value++;
-}
-
-function applyTheme() {
-  document.documentElement.dataset.theme = theme.value;
-  void invoke("set_app_theme", { theme: theme.value }).catch(() => {
-    /* ignore in non-Tauri environments */
-  });
 }
 
 async function exportHtml() {
@@ -887,7 +887,6 @@ let unlistenOpen: (() => void) | null = null;
 let unlistenClose: (() => void) | null = null;
 
 onMounted(async () => {
-  applyTheme();
   applyReadingSettings();
   void checkPandoc().then((info) => (pandocInfo.value = info));
   void checkPdfEngine().then((p) => (pdfEnginePath.value = p));
@@ -1286,7 +1285,7 @@ watch(
         @click="toggleTheme"
         :title="t('app.toggleTheme')"
       >
-        {{ theme === "light" ? "🌙" : "☀️" }}
+        {{ themeIcon }}
       </button>
       <button
         class="btn lang"
@@ -1409,7 +1408,7 @@ watch(
           v-else-if="isEditing"
           ref="editorRef"
           :model-value="draftContent"
-          :theme="theme"
+          :theme="effectiveTheme"
           :current-file="currentFile"
           @update:model-value="onDraftUpdate"
           @toggle-mode="toggleEditorMode"

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,146 @@
+/**
+ * Global theme management module, providing features like light/dark mode switching and system theme awareness.
+ */
+
+import { ref, computed, watch } from "vue";
+import type { Ref, ComputedRef } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { load } from "@tauri-apps/plugin-store";
+
+const STORAGE_FILE = "settings.json";
+const THEME_STORAGE_KEY = "md-reader-theme";
+
+// Initialize Tauri Store
+const store = await load(STORAGE_FILE, { autoSave: false });
+
+// Enumeration for the actual rendered theme color
+export type Theme = "light" | "dark";
+
+// Enumeration for the user-configured theme mode, including the system follow option
+export type ThemeMode = Theme | "system";
+
+// Environment flag: whether it is running in the browser client
+const isClient = typeof window !== "undefined";
+
+// Environment flag: whether it is running in development mode
+const isDev = import.meta.env?.DEV ?? false;
+
+// Internally maintained current theme mode.
+const internalThemeMode: Ref<ThemeMode> = ref("system");
+
+// Asynchronously load the user's theme preference from the Store and update the internal state
+async function initStoredThemeMode() {
+  if (!isClient) return;
+  try {
+    const stored = await store.get<string>(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") {
+      internalThemeMode.value = stored;
+    }
+  } catch (error) {
+    if (isDev) console.warn("[Theme] Failed to read from Tauri Store:", error);
+  }
+}
+
+// Persist the theme mode to the Tauri Store and save it to disk
+async function writeStoredThemeMode(mode: ThemeMode) {
+  if (!isClient) return;
+  try {
+    if (mode === "system") {
+      await store.delete(THEME_STORAGE_KEY);
+      window.localStorage.removeItem(THEME_STORAGE_KEY);
+    } else {
+      await store.set(THEME_STORAGE_KEY, mode);
+      window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+    }
+    // Since autoSave is disabled, save must be called manually
+    await store.save();
+  } catch (error) {
+    if (isDev) console.warn("[Theme] Failed to write to Tauri Store:", error);
+  }
+}
+
+// Asynchronously load the stored theme on startup
+initStoredThemeMode();
+
+// perating system level theme state
+const systemTheme: Ref<Theme> = ref("light");
+
+// Native media query object for operating system theme preferences
+const mediaQuery = isClient
+  ? window.matchMedia("(prefers-color-scheme: dark)")
+  : undefined;
+
+// Initialize system theme state
+if (mediaQuery) {
+  systemTheme.value = mediaQuery.matches ? "dark" : "light";
+}
+
+// eme preference changes
+const handleSystemThemeChange = (event: MediaQueryListEvent) => {
+  const newTheme = event.matches ? "dark" : "light";
+  if (isDev) console.info(`[Theme] System theme changed to: ${newTheme}`);
+  systemTheme.value = newTheme;
+};
+
+// The final effective theme calculated based on the user's mode selection.
+const effectiveTheme: ComputedRef<Theme> = computed(() => {
+  return internalThemeMode.value === "system"
+    ? systemTheme.value
+    : internalThemeMode.value;
+});
+
+// Two-way binding theme mode interface provided for component layer use.
+const themeMode = computed({
+  get: () => internalThemeMode.value,
+  set: (mode: ThemeMode) => {
+    if (isDev) console.info(`[Theme] User set theme mode to: ${mode}`);
+    internalThemeMode.value = mode;
+  },
+});
+
+// Watch for changes to internalThemeMode
+watch(internalThemeMode, (mode) => {
+  writeStoredThemeMode(mode);
+
+  invoke("set_theme_mode", { themeMode: mode }).catch((error) => {
+    if (isDev) console.error("[Theme] IPC error on 'set_theme_mode':", error);
+  });
+});
+
+// Watch for changes to effectiveTheme
+watch(
+  effectiveTheme,
+  (theme) => {
+    if (!isClient) return;
+
+    const root = document.documentElement;
+    root.setAttribute("data-theme", theme);
+    root.style.setProperty("color-scheme", theme);
+
+    invoke("set_effective_theme", { theme }).catch((error) => {
+      if (isDev)
+        console.error("[Theme] IPC error on 'set_effective_theme':", error);
+    });
+  },
+  { immediate: true }
+);
+
+// Mount system-level listeners
+if (isClient) {
+  mediaQuery?.addEventListener("change", handleSystemThemeChange);
+}
+
+// In the development environment, prevent memory leaks caused by Vite Hot Module Replacement (HMR)
+if (import.meta.hot && isClient) {
+  import.meta.hot.dispose(() => {
+    mediaQuery?.removeEventListener("change", handleSystemThemeChange);
+  });
+}
+
+// Vue Composable providing theme access and manipulation
+export function useTheme() {
+  return {
+    themeMode,
+    effectiveTheme,
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(async () => ({
     },
   },
   build: {
+    target: 'es2022',
     chunkSizeWarningLimit: 1500,
     rollupOptions: {
       output: {


### PR DESCRIPTION
* **Added a "Follow System" option to the theme switcher, set as the default.**
* **Automatically adapts to the operating system's light/dark mode preferences when set to "Follow System".**
* **Addressed implementation details to prevent UI theme flickering during application startup.**